### PR TITLE
fix Kansas build (mixed 2016 and earlier data)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -65,7 +65,7 @@ out/18-indiana/state.gpkg: data/18-indiana/157-tippecanoe/precincts.geojson
 		-overwrite -f GPKG out/18-indiana/157-tippecanoe/county.gpkg data/18-indiana/157-tippecanoe/precincts.geojson
 	ogr2ogr -f GPKG -nln state -overwrite $@ out/18-indiana/157-tippecanoe/county.gpkg
 
-out/20-kansas/state.gpkg: data/20-kansas/statewide/2010/KLRD_2010VotingDistricts.geojson.gz data/20-kansas/2016/20045-douglas/precincts.geojson
+out/20-kansas/state.gpkg: data/20-kansas/statewide/2012/kansas-state-voting-precincts-2012.geojson data/20-kansas/2016/20045-douglas/precincts.geojson
 	mkdir -p out/20-kansas
 	mv `scripts/20-kansas.sh` $@
 

--- a/scripts/20-kansas.sh
+++ b/scripts/20-kansas.sh
@@ -7,11 +7,9 @@
 CURDIR=`dirname $0`
 TEMPDIR=`$CURDIR/tmpdir.py kansas-`
 
-gunzip --stdout data/20-kansas/statewide/2010/KLRD_2010VotingDistricts.geojson.gz > $TEMPDIR/state.geojson
-
-ogr2ogr -sql "SELECT '2010' AS year, 'Kansas' AS state, SUBSTR(VTD_2012, 3, 3) AS county, VTD_2012 AS precinct, 'polygon' AS accuracy FROM OGRGeoJSON WHERE SUBSTR(VTD_2012, 3, 3) != '045'" \
+ogr2ogr -sql "SELECT '2012' AS year, 'Kansas' AS state, SUBSTR(VTD_2012, 3, 3) AS county, VTD_2012 AS precinct, 'polygon' AS accuracy FROM OGRGeoJSON WHERE SUBSTR(VTD_2012, 3, 3) != '045'" \
 	-t_srs EPSG:4326 -nln state -nlt MultiPolygon -f GPKG \
-	$TEMPDIR/state.gpkg $TEMPDIR/state.geojson
+	$TEMPDIR/state.gpkg data/20-kansas/statewide/2012/kansas-state-voting-precincts-2012.geojson
 
 #
 # Add Douglas County (FIPS 045) to the statewide Geopackage file.


### PR DESCRIPTION
Somehow the branch still worked in https://github.com/nvkelso/election-geodata/pull/67, but after it merged something changed and it broke. This PR fixes that (note "blue" 2016 data county in sea of "red" earlier date data in Kansas).

![render](https://cloud.githubusercontent.com/assets/853051/23834910/7a1119dc-071b-11e7-9118-f2d944e30121.png)