### PR TITLE
Switch from Circle to Docker

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 out
 .DS_Store
+env.ini

--- a/circle.yml
+++ b/circle.yml
@@ -12,18 +12,4 @@ dependencies:
 
 test:
   override:
-    - make out/render.png out/nation.gpkg
-  post:
-    - aws s3 cp --acl public-read out/render.png s3://$S3_BUCKET/commits/$CIRCLE_SHA1/render.png
-    - scripts/update-status.py https://s3.amazonaws.com/$S3_BUCKET/commits/$CIRCLE_SHA1/render.png
-
-deployment:
-  published:
-    branch: master
-    commands:
-      - aws s3 cp --acl public-read --cache-control 'max-age=60 public' out/render.png s3://$S3_BUCKET/branches/$CIRCLE_BRANCH/render.png
-      - ogr2ogr out/nation.shp out/nation.gpkg
-      - gzip -9 out/nation.gpkg
-      - aws s3 cp --acl public-read --content-encoding gzip --content-type application/geopackage out/nation.gpkg.gz s3://$S3_BUCKET/branches/$CIRCLE_BRANCH/nation.gpkg
-      - zip -j out/nation.zip out/nation.shp out/nation.shx out/nation.prj out/nation.dbf
-      - aws s3 cp --acl public-read --content-type application/zip out/nation.zip s3://$S3_BUCKET/branches/$CIRCLE_BRANCH/nation-shp.zip
+    - echo 'This is fine'

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,13 @@
+FROM ubuntu:14.04
+
+ENV LC_ALL=C.UTF-8
+
+# Install packages additional Ubuntu PPAs.
+RUN apt-get update -y && \
+    apt-get install -y software-properties-common python-software-properties && \
+    add-apt-repository -y ppa:migurski/electionsgeodata
+
+# Install needed binary packages.
+RUN apt-get update -y && \
+    apt-get install -y libgeos-c1v5=3.5.0-1~trusty1 gdal-bin=2.1.0+dfsg-1~trusty2 && \
+    apt-get install -y python-mapnik python-requests imagemagick

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -10,4 +10,11 @@ RUN apt-get update -y && \
 # Install needed binary packages.
 RUN apt-get update -y && \
     apt-get install -y libgeos-c1v5=3.5.0-1~trusty1 gdal-bin=2.1.0+dfsg-1~trusty2 && \
-    apt-get install -y python-mapnik python-requests imagemagick
+    apt-get install -y python-mapnik python-requests imagemagick && \
+    apt-get install -y build-essential zip unzip awscli git
+
+# Install scripts
+COPY build-publish.sh /usr/local/bin/build-publish.sh
+
+# Build and publish (if possible)
+CMD /usr/local/bin/build-publish.sh

--- a/docker/build-publish.sh
+++ b/docker/build-publish.sh
@@ -1,0 +1,32 @@
+#!/bin/sh -ex
+
+# First, check to see if there are any local changes
+# in the repo and refuse to continue if any are found.
+git update-index -q --refresh
+
+if git diff-index --quiet HEAD --; then
+    echo 'Yay: no uncommitted changes found.'
+else
+    echo 'Boo: there are local uncommitted changes.'
+    exit 1
+fi
+
+make clean out/render.png out/nation.gpkg
+
+export GIT_SHA1=`git rev-parse HEAD`
+export GIT_BRANCH=`git rev-parse --abbrev-ref HEAD`
+
+aws --region us-east-1 s3 cp --acl public-read out/render.png s3://$S3_BUCKET/commits/$GIT_SHA1/render.png
+
+if [ $GIT_BRANCH = 'migurski/add-docker-support' ]; then
+
+    aws --region us-east-1 s3 cp --acl public-read --cache-control 'max-age=60 public' out/render.png s3://$S3_BUCKET/branches/$GIT_BRANCH/render.png
+    ogr2ogr out/nation.shp out/nation.gpkg
+    gzip -9 out/nation.gpkg
+    aws --region us-east-1 s3 cp --acl public-read --content-encoding gzip --content-type application/geopackage out/nation.gpkg.gz s3://$S3_BUCKET/branches/$GIT_BRANCH/nation.gpkg
+    zip -j out/nation.zip out/nation.shp out/nation.shx out/nation.prj out/nation.dbf
+    aws --region us-east-1 s3 cp --acl public-read --content-type application/zip out/nation.zip s3://$S3_BUCKET/branches/$GIT_BRANCH/nation-shp.zip
+
+fi
+
+scripts/update-status.py https://s3.amazonaws.com/$S3_BUCKET/commits/$GIT_SHA1/render.png

--- a/env.ini-sample
+++ b/env.ini-sample
@@ -1,0 +1,7 @@
+GITHUB_USERNAME=nvkelso
+GITHUB_REPONAME=election-geodata
+GITHUB_TOKEN=<get one from https://github.com/settings/tokens>
+
+S3_BUCKET=nvkelso-election-geodata
+AWS_ACCESS_KEY_ID=<ask Migurski>
+AWS_SECRET_ACCESS_KEY=<ask Migurski>

--- a/scripts/update-status.py
+++ b/scripts/update-status.py
@@ -4,7 +4,7 @@ import os, sys, requests, json
 
 _, target_url = sys.argv
 auth = os.environ['GITHUB_TOKEN'], 'x-oauth-basic'
-env = [os.environ[key] for key in ('CIRCLE_PROJECT_USERNAME', 'CIRCLE_PROJECT_REPONAME', 'CIRCLE_SHA1')]
+env = [os.environ[key] for key in ('GITHUB_USERNAME', 'GITHUB_REPONAME', 'GIT_SHA1')]
 post_url = 'https://api.github.com/repos/{0}/{1}/commits/{2}/statuses'.format(*env)
 post_data = dict(state="success", context="elections", target_url=target_url, description="Everything is awesome")
 post_body = json.dumps(post_data)


### PR DESCRIPTION
We’ve outgrown Circle CI and need another way to run data and tests. For the time being, it might be acceptable to run this manually under Docker as a jury-rigged replacement.

- [x] Build a Dockerfile with complete dependencies.
- [x] Add Test commands to Dockerfile.
- [x] Add deployment commands to Dockerfile.
- [x] Integrate with Github Statuses.
- [x] Verify that @nvkelso can run this from documentation.
