### PR TITLE
Standardize Kansas county IDs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -355,27 +355,27 @@ out/20-kansas/state.gpkg: data/20-kansas/statewide/2012/kansas_state_voting_prec
 		$@ data/20-kansas/statewide/2012/kansas_state_voting_precincts_2012.geojson
 
 	# Add Douglas County (FIPS 045) to the statewide Geopackage file.
-	ogr2ogr -sql "SELECT '2016' AS year, '20' AS state, '20045' AS county, CONCAT(CAST(precinctid AS character(255)), ' ', CAST(subprecinctid AS character(255))) AS precinct, 'polygon' AS accuracy FROM OGRGeoJSON" \
+	ogr2ogr -sql "SELECT '2016' AS year, '20' AS state, '045' AS county, CONCAT(CAST(precinctid AS character(255)), ' ', CAST(subprecinctid AS character(255))) AS precinct, 'polygon' AS accuracy FROM OGRGeoJSON" \
 		-s_srs EPSG:4326 -t_srs EPSG:4326 -f GPKG -nln state -append \
 		$@ data/20-kansas/2016/20045-douglas/precincts.geojson
 
 	# Add Johnson County (FIPS 091) to the statewide Geopackage file.
-	ogr2ogr -sql "SELECT '2016' AS year, '20' AS state, '20091' AS county, NAME AS precinct, 'polygon' AS accuracy FROM OGRGeoJSON" \
+	ogr2ogr -sql "SELECT '2016' AS year, '20' AS state, '091' AS county, NAME AS precinct, 'polygon' AS accuracy FROM OGRGeoJSON" \
 		-s_srs EPSG:4326 -t_srs EPSG:4326 -f GPKG -nln state -append \
 		$@ data/20-kansas/2016/20091-johnson/precincts.geojson
 
 	# Add Sedgwick County (FIPS 173) to the statewide Geopackage file.
-	ogr2ogr -sql "SELECT '2016' AS year, '20' AS state, '20173' as county, PRECINCT AS precinct, 'polygon' AS accuracy FROM OGRGeoJSON" \
+	ogr2ogr -sql "SELECT '2016' AS year, '20' AS state, '173' as county, PRECINCT AS precinct, 'polygon' AS accuracy FROM OGRGeoJSON" \
 		-s_srs EPSG:4326 -t_srs EPSG:4326 -f GPKG -nln state -append \
 		$@ data/20-kansas/2016/20173-sedgwick/precincts.geojson
 
 	# Add Shawnee County (FIPS 227) to the statewide Geopackage file.
-	ogr2ogr -sql "SELECT '2016' AS year, '20' AS state, '20227' as county, SUBSTR(PRECINCTID, 3, 6) AS precinct, 'polygon' AS accuracy FROM OGRGeoJSON" \
+	ogr2ogr -sql "SELECT '2016' AS year, '20' AS state, '227' as county, SUBSTR(PRECINCTID, 3, 6) AS precinct, 'polygon' AS accuracy FROM OGRGeoJSON" \
 		-s_srs EPSG:4326 -t_srs EPSG:4326 -f GPKG -nln state -append \
 		$@ data/20-kansas/2016/20227-shawnee/precincts.geojson
 
 	# Add Wyandotte County (FIPS 209) to the statewide Geopackage file.
-	ogr2ogr -sql "SELECT '2016' AS year, '20' AS state, '20209' as county, VTD_S AS precinct, 'polygon' AS accuracy FROM OGRGeoJSON" \
+	ogr2ogr -sql "SELECT '2016' AS year, '20' AS state, '209' as county, VTD_S AS precinct, 'polygon' AS accuracy FROM OGRGeoJSON" \
 		-s_srs EPSG:4326 -t_srs EPSG:4326 -f GPKG -nln state -append \
 		$@ data/20-kansas/2016/20209-wyandotte/precincts.geojson
 


### PR DESCRIPTION
This PR standardizes Kansas counties to use 3-digit county-only FIPS codes.

Closes #157.